### PR TITLE
FIxed coming soon height issue and redirected blogs and case studies to coming soon

### DIFF
--- a/src/lib/components/ui/header/header.svelte
+++ b/src/lib/components/ui/header/header.svelte
@@ -51,14 +51,14 @@
 				</span>
 			</a>
 
-			<a class="blogs" href="/blogs">
+			<a class="blogs" href="/coming-soon">
 				<p class="text-base">Blogs</p>
 				<span>
 					<MobileArrow />
 				</span>
 			</a>
 
-			<a class="cases" href="/case-study">
+			<a class="cases" href="/coming-soon">
 				<p class="text-base">Case Study</p>
 				<span>
 					<MobileArrow />

--- a/src/routes/coming-soon/+page.svelte
+++ b/src/routes/coming-soon/+page.svelte
@@ -46,6 +46,7 @@
 <style>
 	.wrapper {
 		background: linear-gradient(170deg, #e1fbdc 0%, #e1fbdc 60%, #b3da41b2 100%);
+		height: 100vh;
 	}
 
 	.first-letter {


### PR DESCRIPTION
- [x] Made the coming soon height full again. (Somehow, the change I made missed while merging multiple PR at once, I thinks it's due to I removed the html, body - height 100% style.)
- [x] In Header mobile view, while clicking on blogs and case studies I redirected it to coming soon page as of now.